### PR TITLE
Add phase-2 reco and calibration workflows

### DIFF
--- a/analyses/DTNtupleDigiAnalyzer.C
+++ b/analyses/DTNtupleDigiAnalyzer.C
@@ -166,8 +166,6 @@ void DTNtupleDigiAnalyzer::fill()
       int wire = ph2Digi_wire->at(iDigi);
       int slAndLay = (lay - 1) + (sl - 1) * 4;
 
-      std::vector wireId = {sl, lay, wire};
-
       double time = ph2Digi_time->at(iDigi) - ph2DigiPedestal;
       double timeInRange = std::max(0.5,std::min(4999.5,time));
       

--- a/configForSliceTestAnalysis.csh
+++ b/configForSliceTestAnalysis.csh
@@ -1,4 +1,4 @@
-setenv CMSSW_FOLDER /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/OfflineCode/SliceTest/v9.1/CMSSW_10_6_5_patch1/
+setenv CMSSW_FOLDER /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/OfflineCode/SliceTest/v9.1.1/CMSSW_10_6_5_patch1/
 setenv CRAB_CONFIG_SCRIPT /cvmfs/cms.cern.ch/crab3/crab.sh
  
 cd ${CMSSW_FOLDER}/src

--- a/configForSliceTestAnalysis.csh
+++ b/configForSliceTestAnalysis.csh
@@ -1,4 +1,4 @@
-setenv CMSSW_FOLDER /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/OfflineCode/SliceTest/v7/CMSSW_10_6_0/
+setenv CMSSW_FOLDER /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/OfflineCode/SliceTest/v9.1/CMSSW_10_6_5_patch1/
 setenv CRAB_CONFIG_SCRIPT /cvmfs/cms.cern.ch/crab3/crab.sh
  
 cd ${CMSSW_FOLDER}/src

--- a/configForSliceTestAnalysis.sh
+++ b/configForSliceTestAnalysis.sh
@@ -1,4 +1,4 @@
-CMSSW_FOLDER=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/OfflineCode/SliceTest/v7/CMSSW_10_6_0/
+CMSSW_FOLDER=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/OfflineCode/SliceTest/v9.1/CMSSW_10_6_5_patch1/
 CRAB_CONFIG_SCRIPT=/cvmfs/cms.cern.ch/crab3/crab.sh
  
 cd $CMSSW_FOLDER/src

--- a/configForSliceTestAnalysis.sh
+++ b/configForSliceTestAnalysis.sh
@@ -1,4 +1,4 @@
-CMSSW_FOLDER=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/OfflineCode/SliceTest/v9.1/CMSSW_10_6_5_patch1/
+CMSSW_FOLDER=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DT/OfflineCode/SliceTest/v9.1.1/CMSSW_10_6_5_patch1/
 CRAB_CONFIG_SCRIPT=/cvmfs/cms.cern.ch/crab3/crab.sh
  
 cd $CMSSW_FOLDER/src

--- a/production/calib/README.md
+++ b/production/calib/README.md
@@ -1,0 +1,33 @@
+# DTSliceTestOfflineAnalysis / production / calib
+A few instructions about how to run calibrations
+
+## Run t0i production for phase-2
+```
+# Print command line options
+python dtT0WireCalibration_cfg.py --help 
+
+# Get t0i out of a specific test-pulse run
+cmsRun dtT0WireCalibration_cfg.py runNumber=333364 \
+       				  runOnDat=True    \
+				  inputFolderCentral=/eos/cms/store/t0streamer/Minidaq/A/
+```
+
+## Run tTrig production
+```
+# Run the tTrig production workflow
+# using t0 from the previous step (./t0_run333364.db)
+dtCalibration ttrig timeboxes all --run=333369 --trial=1 --label=ttrig_timebox \
+	      	    	      	  --runselection=333369 --datasetpath=/Dummy/Dummy/RAW \
+				  --globaltag=106X_dataRun3_Express_v2  --datasettype=Cosmics \
+				  --run-on-RAW --phase2 --inputT0DB ./t0_run333364.db --input-files-local 
+```
+
+## Run ntuples with the new t0i and tTrigs
+```
+cd .. # get back to production directory
+
+cmsRun dtDpgNtuples_slicetest_cfg.py runNumber=333369 \
+       				     tTrigFilePh2=./calib/Run333369-ttrig_timebox_v1/TimeBoxes/results/ttrig_timeboxes_Run333369_v1.db \
+				     t0FilePh2=./calib/t0_run333364.db
+```
+

--- a/production/calib/README.md
+++ b/production/calib/README.md
@@ -7,27 +7,25 @@ A few instructions about how to run calibrations
 python dtT0WireCalibration_cfg.py --help 
 
 # Get t0i out of a specific test-pulse run
-cmsRun dtT0WireCalibration_cfg.py runNumber=333364 \
-       				  runOnDat=True    \
-				  inputFolderCentral=/eos/cms/store/t0streamer/Minidaq/A/
+cmsRun dtT0WireCalibration_cfg.py runNumber=333514
 ```
 
 ## Run tTrig production
 ```
 # Run the tTrig production workflow
 # using t0 from the previous step (./t0_run333364.db)
-dtCalibration ttrig timeboxes all --run=333369 --trial=1 --label=ttrig_timebox \
-	      	    	      	  --runselection=333369 --datasetpath=/Dummy/Dummy/RAW \
+dtCalibration ttrig timeboxes all --run=333510 --trial=1 --label=ttrig_timebox \
+	      	    	      	  --runselection=333510 --datasetpath=/Dummy/Dummy/RAW \
 				  --globaltag=106X_dataRun3_Express_v2  --datasettype=Cosmics \
-				  --run-on-RAW --phase2 --inputT0DB ./t0_run333364.db --input-files-local 
+				  --run-on-RAW --phase2 --inputT0DB ./t0_run333514.db --input-files-local
 ```
 
 ## Run ntuples with the new t0i and tTrigs
 ```
 cd .. # get back to production directory
 
-cmsRun dtDpgNtuples_slicetest_cfg.py runNumber=333369 \
-       				     tTrigFilePh2=./calib/Run333369-ttrig_timebox_v1/TimeBoxes/results/ttrig_timeboxes_Run333369_v1.db \
-				     t0FilePh2=./calib/t0_run333364.db
+cmsRun dtDpgNtuples_slicetest_cfg.py nEvents=50000 runNumber=333510 \
+       				     tTrigFilePh2=./calib/Run333510-ttrig_timebox_v1/TimeBoxes/results/ttrig_timeboxes_Run333510_v1.db \
+				     t0FilePh2=./calib/t0_run333514.db
 ```
 

--- a/production/calib/dtT0WireCalibration_cfg.py
+++ b/production/calib/dtT0WireCalibration_cfg.py
@@ -1,0 +1,998 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+import subprocess
+import sys
+import os
+
+process = cms.Process("PROD")
+
+options = VarParsing.VarParsing()
+
+options.register('runNumber',
+                 '333369', #default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,
+                 "Run number to be looked for in either 'inputFolderCentral' or 'inputFolderDT' folders")
+
+options.register('inputFile',
+                 '', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "The input file to be processed, if non null overrides runNumber based input file selection")
+
+options.register('inputFolderCentral',
+                 '/eos/cms/store/data/Commissioning2019/MiniDaq/RAW/v1/', #default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                 "Base EOS folder with input files from MiniDAQ runs with central tier0 transfer")
+
+options.register('inputFolderDT',
+                 '/eos/cms/store/group/dpg_dt/comm_dt/commissioning_2019_data/root/', #default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                 "Base EOS folder with input files from MiniDAQ runs with DT 'private' tier0 transfer")
+
+options.register('runOnDat',
+                 False, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "If set to True switches source from 'PoolSource' to 'NewEventStreamFileReader'")
+
+options.parseArguments()
+
+if options.runOnDat :
+    inputSourceType = "NewEventStreamFileReader"
+else:
+    inputSourceType = "PoolSource"
+
+process.source = cms.Source(inputSourceType,
+                            
+        fileNames = cms.untracked.vstring()
+)
+
+if options.inputFile != '' :
+
+    print "[dtT0WireCalibration_cfg.py]: inputFile parameter is non-null running on file:\n\t\t\t" + options.inputFile
+    process.source.fileNames = cms.untracked.vstring("file://" + options.inputFile)
+
+else :
+
+    runStr = str(options.runNumber).zfill(9)
+    runFolder = options.inputFolderCentral + "/" + runStr[0:3] + "/" + runStr[3:6] + "/" + runStr[6:] 
+    if not options.runOnDat:
+        runFolder = runFolder + "/00000"
+    
+    print "[dtT0WireCalibration_cfg.py]: looking for files under:\n\t\t\t" + runFolder
+    
+    if os.path.exists(runFolder) :
+        files = subprocess.check_output(["ls", runFolder])
+        process.source.fileNames = ["file://" + runFolder + "/" + f for f in files.split()]
+
+    else :
+        print "[dtT0WireCalibration_cfg.py]: files not found there, looking under:\n\t\t\t" + options.inputFolderDT
+
+        files = subprocess.check_output(["ls", options.inputFolderDT])
+        filesFromRun = []
+
+        for f in files.split() :
+            if f.find(runStr[3:]) > -1 :
+                filesFromRun.append(f)
+
+        if len(filesFromRun) == 1 :
+            process.source.fileNames.append("file://" + options.inputFolderDT + "/" + filesFromRun[0])
+
+        else :
+            print "[dtT0WireCalibration_cfg.py]: " + str(len(filesFromRun)) + " files found, can't run!"
+            sys.exit(999)
+
+print "[dtT0WireCalibration_cfg.py]: files:\n", process.source.fileNames
+
+process.CondDB = cms.PSet(
+    DBParameters = cms.PSet(
+        authenticationPath = cms.untracked.string(''),
+        authenticationSystem = cms.untracked.int32(0),
+        messageLevel = cms.untracked.int32(0),
+        security = cms.untracked.string('')
+    ),
+    connect = cms.string('')
+)
+
+process.HFRecalParameterBlock = cms.PSet(
+    HFdepthOneParameterA = cms.vdouble(
+        0.004123, 0.00602, 0.008201, 0.010489, 0.013379, 
+        0.016997, 0.021464, 0.027371, 0.034195, 0.044807, 
+        0.058939, 0.125497
+    ),
+    HFdepthOneParameterB = cms.vdouble(
+        -4e-06, -2e-06, 0.0, 4e-06, 1.5e-05, 
+        2.6e-05, 6.3e-05, 8.4e-05, 0.00016, 0.000107, 
+        0.000425, 0.000209
+    ),
+    HFdepthTwoParameterA = cms.vdouble(
+        0.002861, 0.004168, 0.0064, 0.008388, 0.011601, 
+        0.014425, 0.018633, 0.023232, 0.028274, 0.035447, 
+        0.051579, 0.086593
+    ),
+    HFdepthTwoParameterB = cms.vdouble(
+        -2e-06, -0.0, -7e-06, -6e-06, -2e-06, 
+        1e-06, 1.9e-05, 3.1e-05, 6.7e-05, 1.2e-05, 
+        0.000157, -3e-06
+    )
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.options = cms.untracked.PSet(
+    wantSummary = cms.untracked.bool(True)
+)
+
+process.MEtoEDMConverter = cms.EDProducer("MEtoEDMConverter",
+    Frequency = cms.untracked.int32(50),
+    MEPathToSave = cms.untracked.string(''),
+    Name = cms.untracked.string('MEtoEDMConverter'),
+    Verbosity = cms.untracked.int32(0),
+    deleteAfterCopy = cms.untracked.bool(True)
+)
+
+
+process.dtTPmonitor = cms.EDProducer("DTDigiTask",
+    ResetCycle = cms.untracked.int32(400),
+    checkNoisyChannels = cms.untracked.bool(True),
+    debug = cms.untracked.bool(False),
+    defaultTmax = cms.int32(100),
+    defaultTtrig = cms.int32(600),
+    doAllHitsOccupancies = cms.untracked.bool(False),
+    doInTimeOccupancies = cms.untracked.bool(True),
+    doLayerTimeBoxes = cms.untracked.bool(False),
+    doNoiseOccupancies = cms.untracked.bool(False),
+    dtDigiLabel = cms.InputTag("dtunpacker"),
+    filterSyncNoise = cms.untracked.bool(False),
+    inTimeHitsLowerBound = cms.int32(0),
+    inTimeHitsUpperBound = cms.int32(0),
+    localrun = cms.untracked.bool(True),
+    maxTDCHitsPerChamber = cms.untracked.int32(100),
+    maxTTMounts = cms.untracked.int32(1600),
+    performPerWireT0Calibration = cms.bool(True),
+    readDB = cms.untracked.bool(False),
+    sliceTestMode = cms.untracked.bool(False),
+    staticBooking = cms.untracked.bool(True),
+    tdcPedestal = cms.untracked.int32(105100),
+    testPulseMode = cms.untracked.bool(True),
+    timeBoxGranularity = cms.untracked.int32(4)
+)
+
+
+process.dtTPmonitorTest = cms.EDProducer("DTOccupancyTest",
+    runOnAllHitsOccupancies = cms.untracked.bool(False),
+    runOnInTimeOccupancies = cms.untracked.bool(True),
+    runOnNoiseOccupancies = cms.untracked.bool(False),
+    testPulseMode = cms.untracked.bool(True)
+)
+
+
+process.dtunpacker = cms.EDProducer("OglezDTAB7RawToDigi",
+    DTAB7_FED_Source = cms.InputTag("rawDataCollector"),
+    channelMapping = cms.untracked.string('july2019'),
+    debug = cms.untracked.bool(False),
+    doHexDumping = cms.untracked.bool(False),
+    feds = cms.untracked.vint32(1368),
+    rawTPVars = cms.untracked.bool(False),
+    xShiftFilename = cms.string('/afs/cern.ch/user/j/joroemer/private/dtcalib/slice_test/CMSSW_10_6_1_patch2/src/L1Trigger/DTPhase2Trigger/data/wire_rawId_x.txt'),
+    zShiftFilename = cms.string('/afs/cern.ch/user/j/joroemer/private/dtcalib/slice_test/CMSSW_10_6_1_patch2/src/L1Trigger/DTPhase2Trigger/data/wire_rawId_z.txt')
+)
+
+
+process.dtunpackerPhase2 = cms.EDProducer("OglezDTAB7RawToDigi",
+    DTAB7_FED_Source = cms.InputTag("rawDataCollector"),
+    channelMapping = cms.untracked.string('july2019'),
+    debug = cms.untracked.bool(False),
+    doHexDumping = cms.untracked.bool(False),
+    feds = cms.untracked.vint32(1368),
+    rawTPVars = cms.untracked.bool(False),
+    xShiftFilename = cms.string('/afs/cern.ch/user/j/joroemer/private/dtcalib/slice_test/CMSSW_10_6_1_patch2/src/L1Trigger/DTPhase2Trigger/data/wire_rawId_x.txt'),
+    zShiftFilename = cms.string('/afs/cern.ch/user/j/joroemer/private/dtcalib/slice_test/CMSSW_10_6_1_patch2/src/L1Trigger/DTPhase2Trigger/data/wire_rawId_z.txt')
+)
+
+
+process.eventInfoProvider = cms.EDFilter("EventCoordinatesSource",
+    eventInfoFolder = cms.untracked.string('EventInfo/')
+)
+
+
+process.dtT0WireCalibration = cms.EDAnalyzer("DTT0Calibration",
+    calibSector = cms.untracked.string('All'),
+    calibWheel = cms.untracked.string('All'),
+    cellsWithHisto = cms.untracked.vstring(),
+    correctByChamberMean = cms.bool(False),
+    debug = cms.untracked.bool(False),
+    digiLabel = cms.untracked.string('dtunpacker'),
+    eventsForLayerT0 = cms.uint32(500),
+    eventsForWireT0 = cms.uint32(500),
+    rejectDigiFromPeak = cms.uint32(100),
+    rootFileName = cms.untracked.string('DTTestPulses.root'),
+    timeBoxWidth = cms.uint32(300),
+    tpPeakWidth = cms.double(15.0),
+    tpPeakWidthPerLayer = cms.double(2.0),
+    histosForAllWires = cms.untracked.bool(True)
+)
+
+
+process.output = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('DQM.root'),
+    outputCommands = cms.untracked.vstring(
+        'drop *', 
+        'keep *_MEtoEDMConverter_*_*'
+    )
+)
+
+
+process.DQMStore = cms.Service("DQMStore",
+    LSbasedMode = cms.untracked.bool(False),
+    collateHistograms = cms.untracked.bool(False),
+    enableMultiThread = cms.untracked.bool(False),
+    forceResetOnBeginLumi = cms.untracked.bool(False),
+    referenceFileName = cms.untracked.string(''),
+    saveByLumi = cms.untracked.bool(False),
+    verbose = cms.untracked.int32(0),
+    verboseQT = cms.untracked.int32(0)
+)
+
+
+process.MessageLogger = cms.Service("MessageLogger",
+    FrameworkJobReport = cms.untracked.PSet(
+        FwkJob = cms.untracked.PSet(
+            limit = cms.untracked.int32(10000000),
+            optionalPSet = cms.untracked.bool(True)
+        ),
+        default = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        optionalPSet = cms.untracked.bool(True)
+    ),
+    categories = cms.untracked.vstring(
+        'FwkJob', 
+        'FwkReport', 
+        'FwkSummary', 
+        'Root_NoDictionary', 
+        'resolution'
+    ),
+    cerr = cms.untracked.PSet(
+        DEBUG = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        FwkReport = cms.untracked.PSet(
+            limit = cms.untracked.int32(100),
+            reportEvery = cms.untracked.int32(1000)
+        ),
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        noLineBreaks = cms.untracked.bool(False),
+        resolution = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+        ),
+        threshold = cms.untracked.string('DEBUG')
+    ),
+    cerr_stats = cms.untracked.PSet(
+        optionalPSet = cms.untracked.bool(True),
+        output = cms.untracked.string('cerr'),
+        threshold = cms.untracked.string('WARNING')
+    ),
+    cout = cms.untracked.PSet(
+        placeholder = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*'),
+    debugs = cms.untracked.PSet(
+        placeholder = cms.untracked.bool(True)
+    ),
+    default = cms.untracked.PSet(
+
+    ),
+    destinations = cms.untracked.vstring('cerr'),
+    errors = cms.untracked.PSet(
+        placeholder = cms.untracked.bool(True)
+    ),
+    fwkJobReports = cms.untracked.vstring('FrameworkJobReport'),
+    infos = cms.untracked.PSet(
+        Root_NoDictionary = cms.untracked.PSet(
+            limit = cms.untracked.int32(0),
+            optionalPSet = cms.untracked.bool(True)
+        ),
+        optionalPSet = cms.untracked.bool(True),
+        placeholder = cms.untracked.bool(True)
+    ),
+    statistics = cms.untracked.vstring('cerr_stats'),
+    suppressDebug = cms.untracked.vstring(),
+    suppressInfo = cms.untracked.vstring(),
+    suppressWarning = cms.untracked.vstring(),
+    warnings = cms.untracked.PSet(
+        placeholder = cms.untracked.bool(True)
+    )
+)
+
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    DBParameters = cms.PSet(
+        authenticationPath = cms.untracked.string(''),
+        authenticationSystem = cms.untracked.int32(0),
+        messageLevel = cms.untracked.int32(0),
+        security = cms.untracked.string('')
+    ),
+    connect = cms.string('sqlite_file:t0_run' + str(options.runNumber) + '.db'),
+    timetype = cms.untracked.string('runnumber'),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string('DTT0Rcd'),
+        tag = cms.string('t0')
+    ))
+)
+
+
+process.CSCGeometryESModule = cms.ESProducer("CSCGeometryESModule",
+    alignmentsLabel = cms.string(''),
+    appendToDataLabel = cms.string(''),
+    applyAlignment = cms.bool(True),
+    debugV = cms.untracked.bool(False),
+    useCentreTIOffsets = cms.bool(False),
+    useDDD = cms.bool(False),
+    useGangedStripsInME1a = cms.bool(True),
+    useOnlyWiresInME1a = cms.bool(False),
+    useRealWireGeometry = cms.bool(True)
+)
+
+
+process.CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
+    SelectedCalos = cms.vstring(
+        'HCAL', 
+        'ZDC', 
+        'CASTOR', 
+        'EcalBarrel', 
+        'EcalEndcap', 
+        'EcalPreshower', 
+        'TOWER'
+    )
+)
+
+
+process.CaloTopologyBuilder = cms.ESProducer("CaloTopologyBuilder")
+
+
+process.CaloTowerGeometryFromDBEP = cms.ESProducer("CaloTowerGeometryFromDBEP",
+    applyAlignment = cms.bool(False)
+)
+
+
+process.CaloTowerTopologyEP = cms.ESProducer("CaloTowerTopologyEP")
+
+
+process.CastorDbProducer = cms.ESProducer("CastorDbProducer",
+    appendToDataLabel = cms.string('')
+)
+
+
+process.CastorGeometryFromDBEP = cms.ESProducer("CastorGeometryFromDBEP",
+    applyAlignment = cms.bool(False)
+)
+
+
+process.DTGeometryESModule = cms.ESProducer("DTGeometryESModule",
+    alignmentsLabel = cms.string(''),
+    appendToDataLabel = cms.string(''),
+    applyAlignment = cms.bool(True),
+    fromDDD = cms.bool(False)
+)
+
+
+process.EcalBarrelGeometryFromDBEP = cms.ESProducer("EcalBarrelGeometryFromDBEP",
+    applyAlignment = cms.bool(True)
+)
+
+
+process.EcalElectronicsMappingBuilder = cms.ESProducer("EcalElectronicsMappingBuilder")
+
+
+process.EcalEndcapGeometryFromDBEP = cms.ESProducer("EcalEndcapGeometryFromDBEP",
+    applyAlignment = cms.bool(True)
+)
+
+
+process.EcalLaserCorrectionService = cms.ESProducer("EcalLaserCorrectionService")
+
+
+process.EcalPreshowerGeometryFromDBEP = cms.ESProducer("EcalPreshowerGeometryFromDBEP",
+    applyAlignment = cms.bool(True)
+)
+
+
+process.EcalTrigTowerConstituentsMapBuilder = cms.ESProducer("EcalTrigTowerConstituentsMapBuilder",
+    MapFile = cms.untracked.string('Geometry/EcalMapping/data/EndCap_TTMap.txt')
+)
+
+
+process.GlobalTrackingGeometryESProducer = cms.ESProducer("GlobalTrackingGeometryESProducer")
+
+
+process.HcalAlignmentEP = cms.ESProducer("HcalAlignmentEP")
+
+
+process.HcalGeometryFromDBEP = cms.ESProducer("HcalGeometryFromDBEP",
+    applyAlignment = cms.bool(True)
+)
+
+
+process.MuonDetLayerGeometryESProducer = cms.ESProducer("MuonDetLayerGeometryESProducer")
+
+
+process.MuonNumberingInitialization = cms.ESProducer("MuonNumberingInitialization")
+
+
+process.ParabolicParametrizedMagneticFieldProducer = cms.ESProducer("AutoParametrizedMagneticFieldProducer",
+    label = cms.untracked.string('ParabolicMf'),
+    valueOverride = cms.int32(-1),
+    version = cms.string('Parabolic')
+)
+
+
+process.RPCGeometryESModule = cms.ESProducer("RPCGeometryESModule",
+    compatibiltyWith11 = cms.untracked.bool(True),
+    useDDD = cms.untracked.bool(False)
+)
+
+
+process.SiStripRecHitMatcherESProducer = cms.ESProducer("SiStripRecHitMatcherESProducer",
+    ComponentName = cms.string('StandardMatcher'),
+    NSigmaInside = cms.double(3.0),
+    PreFilter = cms.bool(False)
+)
+
+
+process.StripCPEfromTrackAngleESProducer = cms.ESProducer("StripCPEESProducer",
+    ComponentName = cms.string('StripCPEfromTrackAngle'),
+    ComponentType = cms.string('StripCPEfromTrackAngle'),
+    parameters = cms.PSet(
+        mLC_P0 = cms.double(-0.326),
+        mLC_P1 = cms.double(0.618),
+        mLC_P2 = cms.double(0.3),
+        mTEC_P0 = cms.double(-1.885),
+        mTEC_P1 = cms.double(0.471),
+        mTIB_P0 = cms.double(-0.742),
+        mTIB_P1 = cms.double(0.202),
+        mTID_P0 = cms.double(-1.427),
+        mTID_P1 = cms.double(0.433),
+        mTOB_P0 = cms.double(-1.026),
+        mTOB_P1 = cms.double(0.253),
+        maxChgOneMIP = cms.double(6000.0),
+        useLegacyError = cms.bool(False)
+    )
+)
+
+
+process.TrackerRecoGeometryESProducer = cms.ESProducer("TrackerRecoGeometryESProducer")
+
+
+process.VolumeBasedMagneticFieldESProducer = cms.ESProducer("VolumeBasedMagneticFieldESProducerFromDB",
+    debugBuilder = cms.untracked.bool(False),
+    label = cms.untracked.string(''),
+    valueOverride = cms.int32(-1)
+)
+
+
+process.XMLFromDBSource = cms.ESProducer("XMLIdealGeometryESProducer",
+    label = cms.string('Extended'),
+    rootDDName = cms.string('cms:OCMS')
+)
+
+
+process.ZdcGeometryFromDBEP = cms.ESProducer("ZdcGeometryFromDBEP",
+    applyAlignment = cms.bool(False)
+)
+
+
+process.fakeForIdealAlignment = cms.ESProducer("FakeAlignmentProducer",
+    appendToDataLabel = cms.string('fakeForIdeal')
+)
+
+
+process.hcalDDDRecConstants = cms.ESProducer("HcalDDDRecConstantsESModule",
+    appendToDataLabel = cms.string('')
+)
+
+
+process.hcalDDDSimConstants = cms.ESProducer("HcalDDDSimConstantsESModule",
+    appendToDataLabel = cms.string('')
+)
+
+
+process.hcalTopologyIdeal = cms.ESProducer("HcalTopologyIdealEP",
+    Exclude = cms.untracked.string(''),
+    MergePosition = cms.untracked.bool(False),
+    appendToDataLabel = cms.string('')
+)
+
+
+process.hcal_db_producer = cms.ESProducer("HcalDbProducer",
+    dump = cms.untracked.vstring(''),
+    file = cms.untracked.string('')
+)
+
+
+process.idealForDigiCSCGeometry = cms.ESProducer("CSCGeometryESModule",
+    alignmentsLabel = cms.string('fakeForIdeal'),
+    appendToDataLabel = cms.string('idealForDigi'),
+    applyAlignment = cms.bool(False),
+    debugV = cms.untracked.bool(False),
+    useCentreTIOffsets = cms.bool(False),
+    useDDD = cms.bool(False),
+    useGangedStripsInME1a = cms.bool(True),
+    useOnlyWiresInME1a = cms.bool(False),
+    useRealWireGeometry = cms.bool(True)
+)
+
+
+process.idealForDigiDTGeometry = cms.ESProducer("DTGeometryESModule",
+    alignmentsLabel = cms.string('fakeForIdeal'),
+    appendToDataLabel = cms.string('idealForDigi'),
+    applyAlignment = cms.bool(False),
+    fromDDD = cms.bool(False)
+)
+
+
+process.idealForDigiTrackerGeometry = cms.ESProducer("TrackerDigiGeometryESModule",
+    alignmentsLabel = cms.string('fakeForIdeal'),
+    appendToDataLabel = cms.string('idealForDigi'),
+    applyAlignment = cms.bool(False),
+    fromDDD = cms.bool(False)
+)
+
+
+process.siPixelQualityESProducer = cms.ESProducer("SiPixelQualityESProducer",
+    ListOfRecordToMerge = cms.VPSet(
+        cms.PSet(
+            record = cms.string('SiPixelQualityFromDbRcd'),
+            tag = cms.string('')
+        ), 
+        cms.PSet(
+            record = cms.string('SiPixelDetVOffRcd'),
+            tag = cms.string('')
+        )
+    ),
+    siPixelQualityLabel = cms.string('')
+)
+
+
+process.siStripBackPlaneCorrectionDepESProducer = cms.ESProducer("SiStripBackPlaneCorrectionDepESProducer",
+    BackPlaneCorrectionDeconvMode = cms.PSet(
+        label = cms.untracked.string('deconvolution'),
+        record = cms.string('SiStripBackPlaneCorrectionRcd')
+    ),
+    BackPlaneCorrectionPeakMode = cms.PSet(
+        label = cms.untracked.string('peak'),
+        record = cms.string('SiStripBackPlaneCorrectionRcd')
+    ),
+    LatencyRecord = cms.PSet(
+        label = cms.untracked.string(''),
+        record = cms.string('SiStripLatencyRcd')
+    )
+)
+
+
+process.siStripGainESProducer = cms.ESProducer("SiStripGainESProducer",
+    APVGain = cms.VPSet(
+        cms.PSet(
+            Label = cms.untracked.string(''),
+            NormalizationFactor = cms.untracked.double(1.0),
+            Record = cms.string('SiStripApvGainRcd')
+        ), 
+        cms.PSet(
+            Label = cms.untracked.string(''),
+            NormalizationFactor = cms.untracked.double(1.0),
+            Record = cms.string('SiStripApvGain2Rcd')
+        )
+    ),
+    AutomaticNormalization = cms.bool(False),
+    appendToDataLabel = cms.string(''),
+    printDebug = cms.untracked.bool(False)
+)
+
+
+process.siStripLorentzAngleDepESProducer = cms.ESProducer("SiStripLorentzAngleDepESProducer",
+    LatencyRecord = cms.PSet(
+        label = cms.untracked.string(''),
+        record = cms.string('SiStripLatencyRcd')
+    ),
+    LorentzAngleDeconvMode = cms.PSet(
+        label = cms.untracked.string('deconvolution'),
+        record = cms.string('SiStripLorentzAngleRcd')
+    ),
+    LorentzAnglePeakMode = cms.PSet(
+        label = cms.untracked.string('peak'),
+        record = cms.string('SiStripLorentzAngleRcd')
+    )
+)
+
+
+process.siStripQualityESProducer = cms.ESProducer("SiStripQualityESProducer",
+    ListOfRecordToMerge = cms.VPSet(
+        cms.PSet(
+            record = cms.string('SiStripDetVOffRcd'),
+            tag = cms.string('')
+        ), 
+        cms.PSet(
+            record = cms.string('SiStripDetCablingRcd'),
+            tag = cms.string('')
+        ), 
+        cms.PSet(
+            record = cms.string('RunInfoRcd'),
+            tag = cms.string('')
+        ), 
+        cms.PSet(
+            record = cms.string('SiStripBadChannelRcd'),
+            tag = cms.string('')
+        ), 
+        cms.PSet(
+            record = cms.string('SiStripBadFiberRcd'),
+            tag = cms.string('')
+        ), 
+        cms.PSet(
+            record = cms.string('SiStripBadModuleRcd'),
+            tag = cms.string('')
+        ), 
+        cms.PSet(
+            record = cms.string('SiStripBadStripRcd'),
+            tag = cms.string('')
+        )
+    ),
+    PrintDebugOutput = cms.bool(False),
+    ReduceGranularity = cms.bool(False),
+    ThresholdForReducedGranularity = cms.double(0.3),
+    UseEmptyRunInfo = cms.bool(False),
+    appendToDataLabel = cms.string('')
+)
+
+
+process.sistripconn = cms.ESProducer("SiStripConnectivity")
+
+
+process.stripCPEESProducer = cms.ESProducer("StripCPEESProducer",
+    ComponentName = cms.string('stripCPE'),
+    ComponentType = cms.string('SimpleStripCPE'),
+    parameters = cms.PSet(
+
+    )
+)
+
+
+process.trackerGeometryDB = cms.ESProducer("TrackerDigiGeometryESModule",
+    alignmentsLabel = cms.string(''),
+    appendToDataLabel = cms.string(''),
+    applyAlignment = cms.bool(True),
+    fromDDD = cms.bool(False)
+)
+
+
+process.trackerNumberingGeometryDB = cms.ESProducer("TrackerGeometricDetESModule",
+    appendToDataLabel = cms.string(''),
+    fromDDD = cms.bool(False)
+)
+
+
+process.trackerTopology = cms.ESProducer("TrackerTopologyEP",
+    appendToDataLabel = cms.string('')
+)
+
+
+process.GlobalTag = cms.ESSource("PoolDBESSource",
+    DBParameters = cms.PSet(
+        authenticationPath = cms.untracked.string(''),
+        authenticationSystem = cms.untracked.int32(0),
+        messageLevel = cms.untracked.int32(0),
+        security = cms.untracked.string('')
+    ),
+    DumpStat = cms.untracked.bool(False),
+    ReconnectEachRun = cms.untracked.bool(False),
+    RefreshAlways = cms.untracked.bool(False),
+    RefreshEachRun = cms.untracked.bool(False),
+    RefreshOpenIOVs = cms.untracked.bool(False),
+    connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+    globaltag = cms.string('106X_dataRun3_Express_v2'),
+    pfnPostfix = cms.untracked.string(''),
+    pfnPrefix = cms.untracked.string(''),
+    snapshotTime = cms.string(''),
+    toGet = cms.VPSet()
+)
+
+
+process.HcalTimeSlewEP = cms.ESSource("HcalTimeSlewEP",
+    appendToDataLabel = cms.string('HBHE'),
+    timeSlewParametersM2 = cms.VPSet(
+        cms.PSet(
+            slope = cms.double(-3.178648),
+            tmax = cms.double(16.0),
+            tzero = cms.double(23.960177)
+        ), 
+        cms.PSet(
+            slope = cms.double(-1.5610227),
+            tmax = cms.double(10.0),
+            tzero = cms.double(11.977461)
+        ), 
+        cms.PSet(
+            slope = cms.double(-1.075824),
+            tmax = cms.double(6.25),
+            tzero = cms.double(9.109694)
+        )
+    ),
+    timeSlewParametersM3 = cms.VPSet(
+        cms.PSet(
+            cap = cms.double(6.0),
+            tspar0 = cms.double(12.2999),
+            tspar0_siPM = cms.double(0.0),
+            tspar1 = cms.double(-2.19142),
+            tspar1_siPM = cms.double(0.0),
+            tspar2 = cms.double(0.0),
+            tspar2_siPM = cms.double(0.0)
+        ), 
+        cms.PSet(
+            cap = cms.double(6.0),
+            tspar0 = cms.double(15.5),
+            tspar0_siPM = cms.double(0.0),
+            tspar1 = cms.double(-3.2),
+            tspar1_siPM = cms.double(0.0),
+            tspar2 = cms.double(32.0),
+            tspar2_siPM = cms.double(0.0)
+        ), 
+        cms.PSet(
+            cap = cms.double(6.0),
+            tspar0 = cms.double(12.2999),
+            tspar0_siPM = cms.double(0.0),
+            tspar1 = cms.double(-2.19142),
+            tspar1_siPM = cms.double(0.0),
+            tspar2 = cms.double(0.0),
+            tspar2_siPM = cms.double(0.0)
+        ), 
+        cms.PSet(
+            cap = cms.double(6.0),
+            tspar0 = cms.double(12.2999),
+            tspar0_siPM = cms.double(0.0),
+            tspar1 = cms.double(-2.19142),
+            tspar1_siPM = cms.double(0.0),
+            tspar2 = cms.double(0.0),
+            tspar2_siPM = cms.double(0.0)
+        )
+    )
+)
+
+
+process.eegeom = cms.ESSource("EmptyESSource",
+    firstValid = cms.vuint32(1),
+    iovIsRunNotTime = cms.bool(True),
+    recordName = cms.string('EcalMappingRcd')
+)
+
+
+process.es_hardcode = cms.ESSource("HcalHardcodeCalibrations",
+    GainWidthsForTrigPrims = cms.bool(False),
+    HBRecalibration = cms.bool(False),
+    HBmeanenergies = cms.FileInPath('CalibCalorimetry/HcalPlugins/data/meanenergiesHB.txt'),
+    HBreCalibCutoff = cms.double(20.0),
+    HERecalibration = cms.bool(False),
+    HEmeanenergies = cms.FileInPath('CalibCalorimetry/HcalPlugins/data/meanenergiesHE.txt'),
+    HEreCalibCutoff = cms.double(20.0),
+    HFRecalParameterBlock = cms.PSet(
+        HFdepthOneParameterA = cms.vdouble(
+            0.004123, 0.00602, 0.008201, 0.010489, 0.013379, 
+            0.016997, 0.021464, 0.027371, 0.034195, 0.044807, 
+            0.058939, 0.125497
+        ),
+        HFdepthOneParameterB = cms.vdouble(
+            -4e-06, -2e-06, 0.0, 4e-06, 1.5e-05, 
+            2.6e-05, 6.3e-05, 8.4e-05, 0.00016, 0.000107, 
+            0.000425, 0.000209
+        ),
+        HFdepthTwoParameterA = cms.vdouble(
+            0.002861, 0.004168, 0.0064, 0.008388, 0.011601, 
+            0.014425, 0.018633, 0.023232, 0.028274, 0.035447, 
+            0.051579, 0.086593
+        ),
+        HFdepthTwoParameterB = cms.vdouble(
+            -2e-06, -0.0, -7e-06, -6e-06, -2e-06, 
+            1e-06, 1.9e-05, 3.1e-05, 6.7e-05, 1.2e-05, 
+            0.000157, -3e-06
+        )
+    ),
+    HFRecalibration = cms.bool(False),
+    SiPMCharacteristics = cms.VPSet(
+        cms.PSet(
+            crosstalk = cms.double(0.0),
+            nonlin1 = cms.double(1.0),
+            nonlin2 = cms.double(0.0),
+            nonlin3 = cms.double(0.0),
+            pixels = cms.int32(36000)
+        ), 
+        cms.PSet(
+            crosstalk = cms.double(0.0),
+            nonlin1 = cms.double(1.0),
+            nonlin2 = cms.double(0.0),
+            nonlin3 = cms.double(0.0),
+            pixels = cms.int32(2500)
+        ), 
+        cms.PSet(
+            crosstalk = cms.double(0.17),
+            nonlin1 = cms.double(1.00985),
+            nonlin2 = cms.double(7.84089e-06),
+            nonlin3 = cms.double(2.86282e-10),
+            pixels = cms.int32(27370)
+        ), 
+        cms.PSet(
+            crosstalk = cms.double(0.196),
+            nonlin1 = cms.double(1.00546),
+            nonlin2 = cms.double(6.40239e-06),
+            nonlin3 = cms.double(1.27011e-10),
+            pixels = cms.int32(38018)
+        ), 
+        cms.PSet(
+            crosstalk = cms.double(0.17),
+            nonlin1 = cms.double(1.00985),
+            nonlin2 = cms.double(7.84089e-06),
+            nonlin3 = cms.double(2.86282e-10),
+            pixels = cms.int32(27370)
+        ), 
+        cms.PSet(
+            crosstalk = cms.double(0.196),
+            nonlin1 = cms.double(1.00546),
+            nonlin2 = cms.double(6.40239e-06),
+            nonlin3 = cms.double(1.27011e-10),
+            pixels = cms.int32(38018)
+        ), 
+        cms.PSet(
+            crosstalk = cms.double(0.0),
+            nonlin1 = cms.double(1.0),
+            nonlin2 = cms.double(0.0),
+            nonlin3 = cms.double(0.0),
+            pixels = cms.int32(0)
+        )
+    ),
+    hb = cms.PSet(
+        darkCurrent = cms.vdouble(0.0),
+        doRadiationDamage = cms.bool(False),
+        gain = cms.vdouble(0.19),
+        gainWidth = cms.vdouble(0.0),
+        mcShape = cms.int32(125),
+        pedestal = cms.double(3.285),
+        pedestalWidth = cms.double(0.809),
+        photoelectronsToAnalog = cms.double(0.3305),
+        qieOffset = cms.vdouble(-0.49, 1.8, 7.2, 37.9),
+        qieSlope = cms.vdouble(0.912, 0.917, 0.922, 0.923),
+        qieType = cms.int32(0),
+        recoShape = cms.int32(105),
+        zsThreshold = cms.int32(8)
+    ),
+    hbUpgrade = cms.PSet(
+        darkCurrent = cms.vdouble(0.01, 0.015),
+        doRadiationDamage = cms.bool(True),
+        gain = cms.vdouble(0.0006252),
+        gainWidth = cms.vdouble(0),
+        mcShape = cms.int32(206),
+        pedestal = cms.double(17.3),
+        pedestalWidth = cms.double(1.5),
+        photoelectronsToAnalog = cms.double(40.0),
+        qieOffset = cms.vdouble(0.0, 0.0, 0.0, 0.0),
+        qieSlope = cms.vdouble(0.05376, 0.05376, 0.05376, 0.05376),
+        qieType = cms.int32(2),
+        radiationDamage = cms.PSet(
+            depVsNeutrons = cms.vdouble(5.543e-10, 8.012e-10),
+            depVsTemp = cms.double(0.0631),
+            intlumiOffset = cms.double(150),
+            intlumiToNeutrons = cms.double(367000000.0),
+            temperatureBase = cms.double(20),
+            temperatureNew = cms.double(-5)
+        ),
+        recoShape = cms.int32(206),
+        zsThreshold = cms.int32(16)
+    ),
+    he = cms.PSet(
+        darkCurrent = cms.vdouble(0.0),
+        doRadiationDamage = cms.bool(False),
+        gain = cms.vdouble(0.23),
+        gainWidth = cms.vdouble(0),
+        mcShape = cms.int32(125),
+        pedestal = cms.double(3.163),
+        pedestalWidth = cms.double(0.9698),
+        photoelectronsToAnalog = cms.double(0.3305),
+        qieOffset = cms.vdouble(-0.38, 2.0, 7.6, 39.6),
+        qieSlope = cms.vdouble(0.912, 0.916, 0.92, 0.922),
+        qieType = cms.int32(0),
+        recoShape = cms.int32(105),
+        zsThreshold = cms.int32(9)
+    ),
+    heUpgrade = cms.PSet(
+        darkCurrent = cms.vdouble(0.01, 0.015),
+        doRadiationDamage = cms.bool(True),
+        gain = cms.vdouble(0.0006252),
+        gainWidth = cms.vdouble(0),
+        mcShape = cms.int32(206),
+        pedestal = cms.double(17.3),
+        pedestalWidth = cms.double(1.5),
+        photoelectronsToAnalog = cms.double(40.0),
+        qieOffset = cms.vdouble(0.0, 0.0, 0.0, 0.0),
+        qieSlope = cms.vdouble(0.05376, 0.05376, 0.05376, 0.05376),
+        qieType = cms.int32(2),
+        radiationDamage = cms.PSet(
+            depVsNeutrons = cms.vdouble(5.543e-10, 8.012e-10),
+            depVsTemp = cms.double(0.0631),
+            intlumiOffset = cms.double(75),
+            intlumiToNeutrons = cms.double(29200000.0),
+            temperatureBase = cms.double(20),
+            temperatureNew = cms.double(5)
+        ),
+        recoShape = cms.int32(206),
+        zsThreshold = cms.int32(16)
+    ),
+    hf = cms.PSet(
+        darkCurrent = cms.vdouble(0.0),
+        doRadiationDamage = cms.bool(False),
+        gain = cms.vdouble(0.14, 0.135),
+        gainWidth = cms.vdouble(0.0, 0.0),
+        mcShape = cms.int32(301),
+        pedestal = cms.double(9.354),
+        pedestalWidth = cms.double(2.516),
+        photoelectronsToAnalog = cms.double(0.0),
+        qieOffset = cms.vdouble(-0.87, 1.4, 7.8, -29.6),
+        qieSlope = cms.vdouble(0.359, 0.358, 0.36, 0.367),
+        qieType = cms.int32(0),
+        recoShape = cms.int32(301),
+        zsThreshold = cms.int32(-9999)
+    ),
+    hfUpgrade = cms.PSet(
+        darkCurrent = cms.vdouble(0.0),
+        doRadiationDamage = cms.bool(False),
+        gain = cms.vdouble(0.14, 0.135),
+        gainWidth = cms.vdouble(0.0, 0.0),
+        mcShape = cms.int32(301),
+        pedestal = cms.double(13.33),
+        pedestalWidth = cms.double(3.33),
+        photoelectronsToAnalog = cms.double(0.0),
+        qieOffset = cms.vdouble(0.0697, -0.7405, 12.38, -671.9),
+        qieSlope = cms.vdouble(0.297, 0.298, 0.298, 0.313),
+        qieType = cms.int32(1),
+        recoShape = cms.int32(301),
+        zsThreshold = cms.int32(-9999)
+    ),
+    ho = cms.PSet(
+        darkCurrent = cms.vdouble(0.0),
+        doRadiationDamage = cms.bool(False),
+        gain = cms.vdouble(0.006, 0.0087),
+        gainWidth = cms.vdouble(0.0, 0.0),
+        mcShape = cms.int32(201),
+        pedestal = cms.double(12.06),
+        pedestalWidth = cms.double(0.6285),
+        photoelectronsToAnalog = cms.double(4.0),
+        qieOffset = cms.vdouble(-0.44, 1.4, 7.1, 38.5),
+        qieSlope = cms.vdouble(0.907, 0.915, 0.92, 0.921),
+        qieType = cms.int32(0),
+        recoShape = cms.int32(201),
+        zsThreshold = cms.int32(24)
+    ),
+    iLumi = cms.double(-1.0),
+    killHE = cms.bool(False),
+    testHEPlan1 = cms.bool(False),
+    testHFQIE10 = cms.bool(False),
+    toGet = cms.untracked.vstring('GainWidths'),
+    useHBUpgrade = cms.bool(False),
+    useHEUpgrade = cms.bool(False),
+    useHFUpgrade = cms.bool(False),
+    useHOUpgrade = cms.bool(True),
+    useIeta18depth1 = cms.bool(True),
+    useLayer0Weight = cms.bool(False)
+)
+
+
+process.prefer("es_hardcode")
+
+process.p = cms.Path(process.dtunpacker+process.dtTPmonitor+process.dtTPmonitorTest+process.dtT0WireCalibration+process.MEtoEDMConverter)
+
+
+process.outpath = cms.EndPath(process.output)
+
+

--- a/production/crab_dtDpgNtuples_slicetest_cfg.py
+++ b/production/crab_dtDpgNtuples_slicetest_cfg.py
@@ -3,7 +3,7 @@ config = Configuration()
 
 ##### Configuration parameters ################################
 
-runNumber = 330160
+runNumber = 333369
 inputDataset = "/Cosmics/Commissioning2019-v1/RAW"
 
 # These are the cfg parameters used to configure the 
@@ -15,7 +15,10 @@ configParams = ['ntupleName=DTDPGNtuple.root']
 
 # These are the additional input files (e.g. sqlite .db) 
 # needed by dtDpgNtuples_slicetest_cfg.py to run
-inputFiles = [] 
+inputFiles = [
+    '/eos/cms/store/group/dpg_dt/comm_dt/commissioning_2019_data/calib/ttrig_phase2_Run333369.db',
+    '/eos/cms/store/group/dpg_dt/comm_dt/commissioning_2019_data/calib/t0_phase2_Run333364.db'
+] 
 # E.g. use dedicated tTrigs
 # inputFiles = ['./calib/TTrigDB_cosmics_ttrig.db'] 
 

--- a/production/crab_dtDpgNtuples_slicetest_cfg.py
+++ b/production/crab_dtDpgNtuples_slicetest_cfg.py
@@ -40,7 +40,7 @@ config.Data.splitting    = 'LumiBased'
 config.Data.unitsPerJob  = 10  
 config.Data.runRange     = str(runNumber)
 config.Data.inputDBS     = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader/'
-config.Data.outLFNDirBase  = '/store/group/dpg_dt/comm_dt/commissioning_2019_data/crab/carlo'
+config.Data.outLFNDirBase  = '/store/group/dpg_dt/comm_dt/commissioning_2019_data/crab/'
 
 config.section_('Site')
 config.Site.storageSite = 'T2_CH_CERN'

--- a/production/crab_dtDpgNtuples_slicetest_cfg.py
+++ b/production/crab_dtDpgNtuples_slicetest_cfg.py
@@ -3,8 +3,8 @@ config = Configuration()
 
 ##### Configuration parameters ################################
 
-runNumber = 333369
-inputDataset = "/Cosmics/Commissioning2019-v1/RAW"
+runNumber = 333510
+inputDataset = "/MiniDaq/Commissioning2019-v1/RAW"
 
 # These are the cfg parameters used to configure the 
 # dtDpgNtuples_slicetest_cfg.py configuration file
@@ -15,10 +15,7 @@ configParams = ['ntupleName=DTDPGNtuple.root']
 
 # These are the additional input files (e.g. sqlite .db) 
 # needed by dtDpgNtuples_slicetest_cfg.py to run
-inputFiles = [
-    '/eos/cms/store/group/dpg_dt/comm_dt/commissioning_2019_data/calib/ttrig_phase2_Run333369.db',
-    '/eos/cms/store/group/dpg_dt/comm_dt/commissioning_2019_data/calib/t0_phase2_Run333364.db'
-] 
+inputFiles = [] 
 # E.g. use dedicated tTrigs
 # inputFiles = ['./calib/TTrigDB_cosmics_ttrig.db'] 
 
@@ -43,7 +40,7 @@ config.Data.splitting    = 'LumiBased'
 config.Data.unitsPerJob  = 10  
 config.Data.runRange     = str(runNumber)
 config.Data.inputDBS     = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader/'
-config.Data.outLFNDirBase  = '/store/group/dpg_dt/comm_dt/commissioning_2019_data/crab/'
+config.Data.outLFNDirBase  = '/store/group/dpg_dt/comm_dt/commissioning_2019_data/crab/carlo'
 
 config.section_('Site')
 config.Site.storageSite = 'T2_CH_CERN'

--- a/production/dtDpgNtuples_slicetest_cfg.py
+++ b/production/dtDpgNtuples_slicetest_cfg.py
@@ -21,7 +21,7 @@ options.register('nEvents',
                  "Maximum number of processed events")
 
 options.register('runNumber',
-                 '333369', #default value
+                 '333510', #default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.int,
                  "Run number to be looked for in either 'inputFolderCentral' or 'inputFolderDT' folders")
@@ -57,13 +57,13 @@ options.register('t0File',
                  "File with customised DT legacy t0is, used only if non ''")
 
 options.register('tTrigFilePh2',
-                 '/eos/cms/store/group/dpg_dt/comm_dt/commissioning_2019_data/calib/ttrig_phase2_Run333369.db', #default value
+                 '', #default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
                  "File with customised DT phase-2 tTrigs, used only if non ''")
 
 options.register('t0FilePh2',
-                 '/eos/cms/store/group/dpg_dt/comm_dt/commissioning_2019_data/calib/t0_phase2_Run333364.db', #default value
+                 '', #default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
                  "File with customised DT phase-2 t0is, used only if non ''")

--- a/production/dtDpgNtuples_slicetest_cfg.py
+++ b/production/dtDpgNtuples_slicetest_cfg.py
@@ -153,7 +153,7 @@ if options.vDriftFile != '' :
                                         )
                                    )
 
-process.source = cms.Source("inputSourceType",
+process.source = cms.Source(inputSourceType,
                             
         fileNames = cms.untracked.vstring()
 )

--- a/production/dtDpgNtuples_slicetest_cfg.py
+++ b/production/dtDpgNtuples_slicetest_cfg.py
@@ -21,7 +21,7 @@ options.register('nEvents',
                  "Maximum number of processed events")
 
 options.register('runNumber',
-                 '329806', #default value
+                 '333369', #default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.int,
                  "Run number to be looked for in either 'inputFolderCentral' or 'inputFolderDT' folders")
@@ -48,13 +48,26 @@ options.register('tTrigFile',
                  '', #default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
-                 "File with customised DT tTrigs, used only if non ''")
+                 "File with customised DT legacy tTrigs, used only if non ''")
 
 options.register('t0File',
                  '', #default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
-                 "File with customised DT t0is, used only if non ''")
+                 "File with customised DT legacy t0is, used only if non ''")
+
+options.register('tTrigFilePh2',
+                 '/eos/cms/store/group/dpg_dt/comm_dt/commissioning_2019_data/calib/ttrig_phase2_Run333369.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "File with customised DT phase-2 tTrigs, used only if non ''")
+
+options.register('t0FilePh2',
+                 '/eos/cms/store/group/dpg_dt/comm_dt/commissioning_2019_data/calib/t0_phase2_Run333364.db', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "File with customised DT phase-2 t0is, used only if non ''")
+
 
 options.register('vDriftFile',
                  '', #default value
@@ -95,9 +108,11 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condD
 
 process.GlobalTag.globaltag = cms.string(options.globalTag)
 
-if options.tTrigFile  != '' or \
-   options.vDriftFile != '' or \
-   options.t0File != '' :
+if options.tTrigFile    != '' or \
+   options.t0File       != '' or \
+   options.tTrigFilePh2 != '' or \
+   options.t0FilePh2    != '' or \
+   options.vDriftFile   != '' :
     process.GlobalTag.toGet = cms.VPSet()
 
 if options.tTrigFile != '' :
@@ -108,6 +123,29 @@ if options.tTrigFile != '' :
                                         )
                                )
 
+if options.t0File != '' :
+    process.GlobalTag.toGet.append(cms.PSet(record = cms.string("DTT0Rcd"),
+                                            tag = cms.string("t0"),
+                                            connect = cms.string("sqlite_file:" + options.t0File)
+                                        )
+                                   )
+
+if options.tTrigFilePh2 != '' :
+    process.GlobalTag.toGet.append(cms.PSet(record = cms.string("DTTtrigRcd"),
+                                            tag = cms.string("ttrig"),
+                                            connect = cms.string("sqlite_file:" + options.tTrigFilePh2),
+                                            label = cms.untracked.string("cosmics_ph2")
+                                        )
+                               )
+
+if options.t0FilePh2 != '' :
+    process.GlobalTag.toGet.append(cms.PSet(record = cms.string("DTT0Rcd"),
+                                            tag = cms.string("t0"),
+                                            connect = cms.string("sqlite_file:" + options.t0FilePh2),
+                                            label = cms.untracked.string("ph2")
+                                        )
+                                   )
+
 if options.vDriftFile != '' :
     process.GlobalTag.toGet.append(cms.PSet(record = cms.string("DTMtimeRcd"),
                                             tag = cms.string("vDrift"),
@@ -115,18 +153,9 @@ if options.vDriftFile != '' :
                                         )
                                    )
 
-if options.t0File != '' :
-    process.GlobalTag.toGet.append(cms.PSet(record = cms.string("DTT0Rcd"),
-                                            tag = cms.string("t0"),
-                                            connect = cms.string("sqlite_file:" + options.t0File)
-                                        )
-                                   )
-    
-
-process.source = cms.Source(inputSourceType,
+process.source = cms.Source("inputSourceType",
                             
-        fileNames = cms.untracked.vstring(),
-
+        fileNames = cms.untracked.vstring()
 )
 
 if options.inputFile != '' :
@@ -140,7 +169,7 @@ else :
     runFolder = options.inputFolderCentral + "/" + runStr[0:3] + "/" + runStr[3:6] + "/" + runStr[6:] 
     if not options.runOnDat:
         runFolder = runFolder + "/00000"
-
+    
     print "[dtDpgNtuples_slicetest_cfg.py]: looking for files under:\n\t\t\t" + runFolder
     
     if os.path.exists(runFolder) :
@@ -193,3 +222,7 @@ process.p = cms.Path(process.muonDTDigis
                      + process.bmtfDigis
                      + process.dtlocalrecoT0Seg
                      + process.dtNtupleProducer)
+
+if options.tTrigFilePh2 != '' and options.t0FilePh2 != '' :
+    from DTDPGAnalysis.DTNtuples.customiseDtPhase2Reco_cff import customiseForPhase2Reco
+    process = customiseForPhase2Reco(process,"p", options.tTrigFilePh2, options.t0FilePh2)


### PR DESCRIPTION
This PR:

1. Switches to a new central deployment (unpacker v9.1, latest emulators, code for phase-2 reco/calibration)
1. Adds phase-2 segment reconstruction in production cfg and uses a "recent" run as reference
2. Adds, under the `production/calib` directory, the cfg and instruction to run phase-2 calibration for t0i and tTrig